### PR TITLE
Additional Canvas-only CSS changes

### DIFF
--- a/no-navigation.css
+++ b/no-navigation.css
@@ -1,3 +1,17 @@
 header.header, nav.nav-reading, .nav-container, #sidebar, .navigation, .footer {
     display: none;
 }
+
+html .wrapper, .wrapper #wrap, .wrapper #wrap, #content{
+  margin: 0;
+}
+
+div#wrap, div#content {
+  width: 100%;
+  max-width: 750px;
+  box-sizing: border-box;
+}
+
+.single-chapter #content {
+  padding: 0 10px 0 35px; 
+}


### PR DESCRIPTION
These changes move main text block to the left of the pane in Canvas and set a max-width of 750px. This will make activities more readable and give learners more room to expand the annotation pane.